### PR TITLE
2010 年から 2015 年にかけて 15〜19 歳の人が減った割合の都道府県ランキングを出力するよう仕様を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,10 +32,10 @@ rl.on('close', () => {
     value.change = value.popu15 / value.popu10;
   }
   const rankingArray = Array.from(prefectureDataMap).sort((pair1, pair2) => {
-    return pair2[1].change - pair1[1].change;
+    return pair1[1].change - pair2[1].change; // 2010 年から 2015 年にかけて 15〜19 歳の人が減った割合の都道府県ランキングのため、昇順ソート
   });
-  const rankingStrings = rankingArray.map(([key, value]) => {
-    return key + ': ' + value.popu10 + '=>' + value.popu15 + ' 変化率:' + value.change;
+  const rankingStrings = rankingArray.map(([key, value],i) => {
+    return (i + 1).toString() + ". " + key + ': ' + value.popu10 + '=>' + value.popu15 + ' 変化率:' + value.change;
   });
   console.log(rankingStrings);
 });


### PR DESCRIPTION
人が増えた割合ランキングから減った割合ランキングを出力するよう、sort処理を修正しました。
また、順位を含む形に出力結果のフォーマットも修正しています。

nodejs学習用のため、マージは不要です。